### PR TITLE
fixed arglist error

### DIFF
--- a/src/gapi/core.clj
+++ b/src/gapi/core.clj
@@ -197,7 +197,7 @@
 	"Return an argument list for the method"
 	[method]
 	(let [base_args
-			(if (= (method :description) "POST") '[auth parameters body] '[auth parameters])]
+			(if (= (method :description) "POST") '[[auth parameters body]] '[[auth parameters]])]
 		base_args))
 
 (defn- extract-methods


### PR DESCRIPTION
I'm getting an error

'cannot convert Symbol to IPersistenVector'

after looking around I found that arglists are meant to be a vector of vectors, so updated this.
